### PR TITLE
windows_subsystem attribute added to native

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(all(windows, not(test)), windows_subsystem = "windows")]
+
 use game_2048_logic::game_main_entry;
 
 fn main() {


### PR DESCRIPTION
if it's not there, the compiled .exe on windows opens a terminal... which we don't want here

only add the attribute on windows targets AND we are not running tests (we still want test outputs, after all)